### PR TITLE
Chore/ci lint build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,13 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+


### PR DESCRIPTION
This PR adds a GitHub Actions workflow (`ci.yml`) that runs:
- npm run lint
- npm run build

Merges to main will now require both checks to pass.
